### PR TITLE
Fixed theme conflict bug

### DIFF
--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -5,7 +5,7 @@ import components from "./components/index"
 // import components from "./components"
 
 const config: ThemeConfig = {
-  initialColorMode: "light",
+  initialColorMode: "dark",
   useSystemColorMode: false,
 }
 


### PR DESCRIPTION
Chakra default was set to light, but theme changer component renders dark by default. Keeping dark the default